### PR TITLE
指定されたグループ数でランダムなグループ分け結果を表示した

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,9 +86,7 @@ const Home: NextPage = () => {
     thNodes.push(<th key={`th-${i}`}>{i + 1}</th>)
   }
 
-  const transposed = transpose(groups)
-
-  const tbodyChildren = transposed.map((rowItems) => {
+  const tbodyChildren = transpose(groups).map((rowItems) => {
     const tds = rowItems.map((item) => {
       return <td key={item}>{item}</td>
     })

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,6 +23,31 @@ const Home: NextPage = () => {
     'たなか',
   ])
 
+  const [group, setGroup] = useState<string[][]>([groupMember])
+
+  const randomGrouping = (groupNumber: number) => {
+    const minMemberNum = groupMember.length / groupNumber
+    const memberNumRest = groupMember.length % groupNumber
+    let currentMember = 0
+    const group = []
+
+    for (let i = 0; i < groupNumber; i++) {
+      if (i < memberNumRest) {
+        group.push(
+          groupMember.slice(currentMember, currentMember + minMemberNum + 1),
+        )
+        currentMember = currentMember + minMemberNum + 1
+      } else {
+        group.push(
+          groupMember.slice(currentMember, currentMember + minMemberNum),
+        )
+        currentMember = currentMember + minMemberNum
+      }
+    }
+
+    return group
+  }
+
   const onChangeTextBox = (event: { target: { value: string } }) => {
     const targetValue = event.target.value
     setGroupNumber(parseInt(targetValue))
@@ -34,6 +59,9 @@ const Home: NextPage = () => {
     } else {
       setErrorMessage('')
     }
+
+    setGroup(randomGrouping(parseInt(targetValue)))
+    console.log(randomGrouping(parseInt(targetValue)))
   }
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,12 +3,37 @@ import Head from 'next/head'
 import { useState } from 'react'
 import styles from '../styles/Home.module.css'
 
+const divideGroups = (groupNumber: number, members: string[]) => {
+  const minMemberNum = Math.floor(members.length / groupNumber)
+  const restMemberNum = members.length % groupNumber
+  let currentMemberIndex = 0
+  const groups = []
+
+  for (let i = 0; i < groupNumber; i++) {
+    const group = members.slice(
+      currentMemberIndex,
+      currentMemberIndex + minMemberNum,
+    )
+    currentMemberIndex = currentMemberIndex + minMemberNum
+
+    const shouldAddRestMember = i < restMemberNum
+    if (shouldAddRestMember) {
+      group.push(members[currentMemberIndex])
+      currentMemberIndex++
+    }
+
+    groups.push(group)
+  }
+
+  return groups
+}
+
 const Home: NextPage = () => {
   const [groupNumber, setGroupNumber] = useState(1)
   const [errorMessage, setErrorMessage] = useState('')
 
   // グループメンバーのダミーデータ
-  const [groupMember] = useState([
+  const [members] = useState([
     'ふじい',
     'あらかわ',
     'あさい',
@@ -23,45 +48,21 @@ const Home: NextPage = () => {
     'たなか',
   ])
 
-  const [group, setGroup] = useState<string[][]>([groupMember])
-
-  const randomGrouping = (groupNumber: number) => {
-    const minMemberNum = groupMember.length / groupNumber
-    const memberNumRest = groupMember.length % groupNumber
-    let currentMember = 0
-    const group = []
-
-    for (let i = 0; i < groupNumber; i++) {
-      if (i < memberNumRest) {
-        group.push(
-          groupMember.slice(currentMember, currentMember + minMemberNum + 1),
-        )
-        currentMember = currentMember + minMemberNum + 1
-      } else {
-        group.push(
-          groupMember.slice(currentMember, currentMember + minMemberNum),
-        )
-        currentMember = currentMember + minMemberNum
-      }
-    }
-
-    return group
-  }
+  const [groups, setGroups] = useState<string[][]>([members])
 
   const onChangeTextBox = (event: { target: { value: string } }) => {
-    const targetValue = event.target.value
-    setGroupNumber(parseInt(targetValue))
+    const parsedTargetValue = parseInt(event.target.value)
+    setGroupNumber(parsedTargetValue)
 
-    groupMember.sort(() => 0.5 - Math.random())
-
-    if (targetValue === '') {
+    if (isNaN(parsedTargetValue)) {
       setErrorMessage('グループ数を指定してください')
+      return
     } else {
       setErrorMessage('')
     }
 
-    setGroup(randomGrouping(parseInt(targetValue)))
-    console.log(randomGrouping(parseInt(targetValue)))
+    members.sort(() => 0.5 - Math.random())
+    setGroups(divideGroups(parsedTargetValue, members))
   }
 
   return (
@@ -93,24 +94,24 @@ const Home: NextPage = () => {
             </thead>
             <tbody>
               <tr>
-                <td>{groupMember[0]}</td>
-                <td>{groupMember[1]}</td>
-                <td>{groupMember[2]}</td>
+                <td>{members[0]}</td>
+                <td>{members[1]}</td>
+                <td>{members[2]}</td>
               </tr>
               <tr>
-                <td>{groupMember[3]}</td>
-                <td>{groupMember[4]}</td>
-                <td>{groupMember[5]}</td>
+                <td>{members[3]}</td>
+                <td>{members[4]}</td>
+                <td>{members[5]}</td>
               </tr>
               <tr>
-                <td>{groupMember[6]}</td>
-                <td>{groupMember[7]}</td>
-                <td>{groupMember[8]}</td>
+                <td>{members[6]}</td>
+                <td>{members[7]}</td>
+                <td>{members[8]}</td>
               </tr>
               <tr>
-                <td>{groupMember[9]}</td>
-                <td>{groupMember[10]}</td>
-                <td>{groupMember[11]}</td>
+                <td>{members[9]}</td>
+                <td>{members[10]}</td>
+                <td>{members[11]}</td>
               </tr>
             </tbody>
           </table>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,6 +28,22 @@ const divideGroups = (groupNumber: number, members: string[]) => {
   return groups
 }
 
+const transpose = (twoDimensionalArray: string[][]) => {
+  const transposedArray: string[][] = []
+
+  for (let i = 0; i < twoDimensionalArray[0].length; i++) {
+    transposedArray[i] = []
+  }
+
+  for (let i = 0; i < twoDimensionalArray.length; i++) {
+    for (let j = 0; j < twoDimensionalArray[i].length; j++) {
+      transposedArray[j].push(twoDimensionalArray[i][j])
+    }
+  }
+
+  return transposedArray
+}
+
 const Home: NextPage = () => {
   const [groupNumber, setGroupNumber] = useState(1)
   const [errorMessage, setErrorMessage] = useState('')
@@ -65,6 +81,20 @@ const Home: NextPage = () => {
     setGroups(divideGroups(parsedTargetValue, members))
   }
 
+  const thNodes: JSX.Element[] = []
+  for (let i = 0; i < groupNumber; i++) {
+    thNodes.push(<th key={`th-${i}`}>{i + 1}</th>)
+  }
+
+  const transposed = transpose(groups)
+
+  const tbodyChildren = transposed.map((rowItems) => {
+    const tds = rowItems.map((item) => {
+      return <td key={item}>{item}</td>
+    })
+    return <tr key={rowItems[0]}>{tds}</tr>
+  })
+
   return (
     <div className={styles.container}>
       <Head>
@@ -86,34 +116,9 @@ const Home: NextPage = () => {
         <div>
           <table border={1}>
             <thead className={styles.tableHead}>
-              <tr>
-                <th>1</th>
-                <th>2</th>
-                <th>3</th>
-              </tr>
+              <tr>{thNodes}</tr>
             </thead>
-            <tbody>
-              <tr>
-                <td>{members[0]}</td>
-                <td>{members[1]}</td>
-                <td>{members[2]}</td>
-              </tr>
-              <tr>
-                <td>{members[3]}</td>
-                <td>{members[4]}</td>
-                <td>{members[5]}</td>
-              </tr>
-              <tr>
-                <td>{members[6]}</td>
-                <td>{members[7]}</td>
-                <td>{members[8]}</td>
-              </tr>
-              <tr>
-                <td>{members[9]}</td>
-                <td>{members[10]}</td>
-                <td>{members[11]}</td>
-              </tr>
-            </tbody>
+            <tbody>{tbodyChildren}</tbody>
           </table>
         </div>
       </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -70,7 +70,7 @@ const Home: NextPage = () => {
     const parsedTargetValue = parseInt(event.target.value)
     setGroupNumber(parsedTargetValue)
 
-    if (isNaN(parsedTargetValue)) {
+    if (isNaN(parsedTargetValue) || parsedTargetValue === 0) {
       setErrorMessage('グループ数を指定してください')
       return
     } else {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,22 @@ import Head from 'next/head'
 import { useState } from 'react'
 import styles from '../styles/Home.module.css'
 
+// グループメンバーのダミーデータ
+const members = [
+  'ふじい',
+  'あらかわ',
+  'あさい',
+  'いいだ',
+  'いしざき',
+  'なかむら',
+  'なかしま',
+  'にしかわ',
+  'おぎや',
+  'おおさか',
+  'さんのう',
+  'たなか',
+]
+
 const divideGroups = (groupNumber: number, members: string[]) => {
   const minMemberNum = Math.floor(members.length / groupNumber)
   const restMemberNum = members.length % groupNumber
@@ -47,22 +63,6 @@ const transpose = (twoDimensionalArray: string[][]) => {
 const Home: NextPage = () => {
   const [groupNumber, setGroupNumber] = useState(1)
   const [errorMessage, setErrorMessage] = useState('')
-
-  // グループメンバーのダミーデータ
-  const [members] = useState([
-    'ふじい',
-    'あらかわ',
-    'あさい',
-    'いいだ',
-    'いしざき',
-    'なかむら',
-    'なかしま',
-    'にしかわ',
-    'おぎや',
-    'おおさか',
-    'さんのう',
-    'たなか',
-  ])
 
   const [groups, setGroups] = useState<string[][]>([members])
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ const Home: NextPage = () => {
   const [errorMessage, setErrorMessage] = useState('')
 
   // グループメンバーのダミーデータ
-  const groupMember = [
+  const [groupMember] = useState([
     'ふじい',
     'あらかわ',
     'あさい',
@@ -21,11 +21,13 @@ const Home: NextPage = () => {
     'おおさか',
     'さんのう',
     'たなか',
-  ]
+  ])
 
   const onChangeTextBox = (event: { target: { value: string } }) => {
     const targetValue = event.target.value
     setGroupNumber(parseInt(targetValue))
+
+    groupMember.sort(() => 0.5 - Math.random())
 
     if (targetValue === '') {
       setErrorMessage('グループ数を指定してください')


### PR DESCRIPTION
作成に当たり以下の項目を行ったので確認をお願いします。

### **issue**
- Resolve #13

### **対応内容**
- メンバーの配列をシャッフルした
    - ['A', 'B', 'C', 'D', 'E', 'F'] => ['B', 'D', 'A', ...]
- メンバーの配列を groupNumber の数だけ分割した
    - groupNumber=3 の時 ['A', 'B', 'C', 'D', 'E', 'F'] => [['A', 'B'], ['C', 'D'], ['E', 'F']]
- 繰り返し文を使ってテーブルを生成した

### **動作確認内容**
1. 初期値でグループ数が1であるとき、テーブルが1列で表示された
2. グループ数に2を入力したとき、テーブルが2列で表示された
3. 再度グループ数に1を入力したとき、テーブルが1列で表示され、1のときとグループのメンバーの並び順が異なっていた
4. コードの自動整形をした

1の動作確認の画像
<img width="133" alt="スクリーンショット 2022-11-10 103801" src="https://user-images.githubusercontent.com/110072048/200979356-33589b5d-84ab-4618-8aef-9aec0e5f0f42.png">
2の動作確認の画像
<img width="144" alt="スクリーンショット 2022-11-10 103824" src="https://user-images.githubusercontent.com/110072048/200979380-a8b6d1eb-c51a-4feb-bc7e-f63f18fd273d.png">
3の動作確認の画像
<img width="121" alt="スクリーンショット 2022-11-10 103849" src="https://user-images.githubusercontent.com/110072048/200979393-816bcfea-957b-4175-ba52-b58e6c1d44a6.png">
