### PR TITLE
エラーメッセージが曖昧なので入力値を限定し、入力値によって表示されるメッセージを変更した

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -106,7 +106,7 @@ const Home: NextPage = () => {
           <input
             type='number'
             min='1'
-            max='20'
+            max={members.length}
             value={groupNumber}
             onChange={onChangeTextBox}
           />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -70,8 +70,16 @@ const Home: NextPage = () => {
     const parsedTargetValue = parseInt(event.target.value)
     setGroupNumber(parsedTargetValue)
 
-    if (isNaN(parsedTargetValue) || parsedTargetValue === 0) {
+    if (isNaN(parsedTargetValue)) {
       setErrorMessage('グループ数を指定してください')
+      return
+    } else if (parsedTargetValue === 0) {
+      setErrorMessage('1以上の整数を入力してください')
+      return
+    } else if (parsedTargetValue > members.length) {
+      setErrorMessage(
+        'メンバー数(' + members.length + ')以下の整数を入力してください',
+      )
       return
     } else {
       setErrorMessage('')

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,15 @@ const members = [
   'たなか',
 ]
 
+const errorMassages = {
+  numOfGroup: {
+    mustBeSpecified: 'グループ数を指定してください',
+    oneOrMore: '1以上の整数を入力してください',
+    menberNumberOrLess:
+      'メンバー数(' + members.length + ')以下の整数を入力してください',
+  },
+}
+
 const divideGroups = (groupNumber: number, members: string[]) => {
   const minMemberNum = Math.floor(members.length / groupNumber)
   const restMemberNum = members.length % groupNumber
@@ -71,15 +80,13 @@ const Home: NextPage = () => {
     setGroupNumber(parsedTargetValue)
 
     if (isNaN(parsedTargetValue)) {
-      setErrorMessage('グループ数を指定してください')
+      setErrorMessage(errorMassages.numOfGroup['mustBeSpecified'])
       return
     } else if (parsedTargetValue === 0) {
-      setErrorMessage('1以上の整数を入力してください')
+      setErrorMessage(errorMassages.numOfGroup['oneOrMore'])
       return
     } else if (parsedTargetValue > members.length) {
-      setErrorMessage(
-        'メンバー数(' + members.length + ')以下の整数を入力してください',
-      )
+      setErrorMessage(errorMassages.numOfGroup['menberNumberOrLess'])
       return
     } else {
       setErrorMessage('')

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,11 +19,11 @@ const members = [
   'たなか',
 ]
 
-const errorMassages = {
-  numOfGroup: {
+const errorMessages = {
+  numOfGroups: {
     mustBeSpecified: 'グループ数を指定してください',
     oneOrMore: '1以上の整数を入力してください',
-    menberNumberOrLess:
+    memberNumberOrLess:
       'メンバー数(' + members.length + ')以下の整数を入力してください',
   },
 }
@@ -80,13 +80,13 @@ const Home: NextPage = () => {
     setGroupNumber(parsedTargetValue)
 
     if (isNaN(parsedTargetValue)) {
-      setErrorMessage(errorMassages.numOfGroup['mustBeSpecified'])
+      setErrorMessage(errorMessages.numOfGroups['mustBeSpecified'])
       return
     } else if (parsedTargetValue === 0) {
-      setErrorMessage(errorMassages.numOfGroup['oneOrMore'])
+      setErrorMessage(errorMessages.numOfGroups['oneOrMore'])
       return
     } else if (parsedTargetValue > members.length) {
-      setErrorMessage(errorMassages.numOfGroup['menberNumberOrLess'])
+      setErrorMessage(errorMessages.numOfGroups['memberNumberOrLess'])
       return
     } else {
       setErrorMessage('')


### PR DESCRIPTION
作成に当たり以下の項目を行ったので確認をお願いします。

### **issue**
- Resolve #23 

### **対応内容**
- グループ数の上限がメンバー数にした
- エラーメッセージの[詳細設計](https://github.com/OJT-3G/random-grouping-app/wiki/%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%81%AE%E8%A9%B3%E7%B4%B0%E8%A8%AD%E8%A8%88(2022%E5%B9%B411%E6%9C%8814%E6%97%A5))をたてた
- 詳細設計の通り入力値によって表示するエラーメッセージを分けた
- コードの自動整形で書式の確認

### **動作確認内容**
1. グループ数をスピンボタンで指定する時上限がメンバー数(12)になり、下限が1になっている
2. グループ数を直接入力する時、適切なエラーメッセージが表示される
    1. 空白の場合「グループ数を指定してください」と表示
    2. 0の場合「1以上の整数を入力してください」と表示
    3. メンバー数以上の場合「メンバー数(12)以下の整数を入力してください」と表示

2のiの動作確認の画像
<img width="187" alt="スクリーンショット 2022-11-15 120610" src="https://user-images.githubusercontent.com/110072048/201816864-e730cf59-f025-48f3-ace9-2deb0c39978d.png">

2のiiの動作確認の画像
<img width="218" alt="スクリーンショット 2022-11-15 120630" src="https://user-images.githubusercontent.com/110072048/201816876-839df6db-e753-4b04-a8c0-1f7d942f727d.png">

2のiiiの動作確認の画像
<img width="253" alt="スクリーンショット 2022-11-15 120652" src="https://user-images.githubusercontent.com/110072048/201816882-73920236-f9fc-435a-8128-0cba0abad27d.png">
