### PR TITLE
メンバーの一覧表示

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -98,21 +98,21 @@ const Home: NextPage = () => {
     setGroups(divideGroups(parsedTargetValue, randomMembers))
   }
 
-  const viewMemberList: JSX.Element[] = []
+  const memberNames: JSX.Element[] = []
   for (let i = 0; i < members.length; i++) {
-    viewMemberList.push(
+    memberNames.push(
       <tr>
         <td>{members[i]}</td>
       </tr>,
     )
   }
 
-  const viewGroupingTitle: JSX.Element[] = []
+  const groupNames: JSX.Element[] = []
   for (let i = 0; i < groupNumber; i++) {
-    viewGroupingTitle.push(<th key={`th-${i}`}>{i + 1}</th>)
+    groupNames.push(<th key={`th-${i}`}>{i + 1}</th>)
   }
 
-  const viewGroupingResults = transpose(groups).map((rowItems) => {
+  const groupMemberNames = transpose(groups).map((rowItems) => {
     const tds = rowItems.map((item) => {
       return <td key={item}>{item}</td>
     })
@@ -145,16 +145,16 @@ const Home: NextPage = () => {
                 <th>名前</th>
               </tr>
             </thead>
-            <tbody>{viewMemberList}</tbody>
+            <tbody>{memberNames}</tbody>
           </table>
         </div>
         <p>グループ分け結果</p>
         <div>
           <table border={1}>
             <thead className={styles.tableHead}>
-              <tr>{viewGroupingTitle}</tr>
+              <tr>{groupNames}</tr>
             </thead>
-            <tbody>{viewGroupingResults}</tbody>
+            <tbody>{groupMemberNames}</tbody>
           </table>
         </div>
       </main>


### PR DESCRIPTION
- #3 
- 希望納期:11/21
- レビュアー: @rknakashima @yk-nakamura @RustyNail
- 仕様書: 無し

# 対応内容

- メンバーの一覧を表示した
- 「グループ数」の文字列のサイズを他の項目と合わせた(文字サイズの変更はMVP実装後で整合をとっていたが以下の理由から対応した)
   - 「グループ数」だけサイズが大きかったのでアプリのタイトルであると勘違いさせないため
   - スタイル指定を取り消すだけなので修正が1行のみであるため
- 表の変数名を統一した

# 動作確認内容

1. メンバーの一覧表示が常に表示される
1. グループ数を変更してもメンバーの一覧は変化しない(以下の画像参照)
1. 「グループ数」の文字列のサイズが他の項目と同じである(以下の画像参照)
<img width="92" alt="スクリーンショット 2022-11-21 105549" src="https://user-images.githubusercontent.com/110072048/202944411-c0796d4f-f01a-4122-9330-8dbc74941248.png">
<img width="109" alt="スクリーンショット 2022-11-21 105620" src="https://user-images.githubusercontent.com/110072048/202944421-8281110f-0866-4f4b-ab12-16faffc7daa1.png">

# マージ前のチェックリスト

- [X] Issue に記載の DoD を満たしている
- [X] `yarn lint` の実行結果のスクリーンショットを添付している
<img width="356" alt="スクリーンショット 2022-11-21 105919" src="https://user-images.githubusercontent.com/110072048/202945249-ddb54673-0650-4a1e-a2b6-6244a3a29ff5.png">

# 補足

- MVP実装時のアプリのUIは[Wiki](https://github.com/OJT-3G/random-grouping-app/wiki/%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AEUI)に記載してある。

- 下記についてはMVPの対応完了後に別issueで対応予定。
  * #27 
  * #17 
  * #16 
  * #25 