### PR TITLE
メンバー調整のためメンバーの追加を出来るようにした

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -203,6 +203,7 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='追加'
+            disabled={errorMessageOfGroupNumber !== ''}
             onClick={onClickAddButton}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -90,14 +90,14 @@ const Home: NextPage = () => {
     setGroupNumber(parsedTargetValue)
 
     if (isNaN(parsedTargetValue)) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups['mustBeSpecified'])
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeSpecified)
       return
     } else if (parsedTargetValue === 0) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups['oneOrMore'])
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.oneOrMore)
       return
     } else if (parsedTargetValue > members.length) {
       setErrorMessageOfGroupNumber(
-        errorMessages.numOfGroups['memberNumberOrLess'],
+        errorMessages.numOfGroups.memberNumberOrLess,
       )
       return
     } else {
@@ -111,11 +111,11 @@ const Home: NextPage = () => {
   const onClickAddButton = () => {
     if (members.indexOf(additionalMember) >= 0) {
       setErrorMessageOfAdditionalMember(
-        errorMessages.nameOfAdditionalMember['mustBeSpecifiedDifferent'],
+        errorMessages.nameOfAdditionalMember.mustBeSpecifiedDifferent,
       )
     } else if (additionalMember === '') {
       setErrorMessageOfAdditionalMember(
-        errorMessages.nameOfAdditionalMember['mustBeSpecified'],
+        errorMessages.nameOfAdditionalMember.mustBeSpecified,
       )
     } else {
       members.push(additionalMember)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -143,7 +143,7 @@ const Home: NextPage = () => {
   const memberNames: JSX.Element[] = []
   for (let i = 0; i < members.length; i++) {
     memberNames.push(
-      <tr>
+      <tr key={members[i]}>
         <td>{members[i]}</td>
       </tr>,
     )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,17 +21,14 @@ const members = [
 
 const randomMembers = [...members]
 
-const errorMessagesOfGroupNumber = {
+const errorMessages = {
   numOfGroups: {
     mustBeSpecified: 'グループ数を指定してください',
     oneOrMore: '1以上の整数を入力してください',
     memberNumberOrLess:
       'メンバー数(' + members.length + ')以下の整数を入力してください',
   },
-}
-
-const errorMessagesOfAdditionalMember = {
-  nameOfMembers: {
+  nameOfAdditionalMember: {
     mustBeSpecified: '名前を入力してください',
     mustBeSpecifiedDifferent:
       'すでに存在する名前です、別の名前を入力してください',
@@ -93,18 +90,14 @@ const Home: NextPage = () => {
     setGroupNumber(parsedTargetValue)
 
     if (isNaN(parsedTargetValue)) {
-      setErrorMessageOfGroupNumber(
-        errorMessagesOfGroupNumber.numOfGroups['mustBeSpecified'],
-      )
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups['mustBeSpecified'])
       return
     } else if (parsedTargetValue === 0) {
-      setErrorMessageOfGroupNumber(
-        errorMessagesOfGroupNumber.numOfGroups['oneOrMore'],
-      )
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups['oneOrMore'])
       return
     } else if (parsedTargetValue > members.length) {
       setErrorMessageOfGroupNumber(
-        errorMessagesOfGroupNumber.numOfGroups['memberNumberOrLess'],
+        errorMessages.numOfGroups['memberNumberOrLess'],
       )
       return
     } else {
@@ -118,13 +111,11 @@ const Home: NextPage = () => {
   const onClickAddButton = () => {
     if (members.indexOf(additionalMember) >= 0) {
       setErrorMessageOfAdditionalMember(
-        errorMessagesOfAdditionalMember.nameOfMembers[
-          'mustBeSpecifiedDifferent'
-        ],
+        errorMessages.nameOfAdditionalMember['mustBeSpecifiedDifferent'],
       )
     } else if (additionalMember === '') {
       setErrorMessageOfAdditionalMember(
-        errorMessagesOfAdditionalMember.nameOfMembers['mustBeSpecified'],
+        errorMessages.nameOfAdditionalMember['mustBeSpecified'],
       )
     } else {
       members.push(additionalMember)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,12 +21,20 @@ const members = [
 
 const randomMembers = [...members]
 
-const errorMessages = {
+const errorMessagesOfGroupNumber = {
   numOfGroups: {
     mustBeSpecified: 'グループ数を指定してください',
     oneOrMore: '1以上の整数を入力してください',
     memberNumberOrLess:
       'メンバー数(' + members.length + ')以下の整数を入力してください',
+  },
+}
+
+const errorMessagesOfAdditionalMember = {
+  nameOfMembers: {
+    mustBeSpecified: '名前を入力してください',
+    mustBeSpecifiedDifferent:
+      'すでに存在する名前です、別の名前を入力してください',
   },
 }
 
@@ -73,29 +81,63 @@ const transpose = (twoDimensionalArray: string[][]) => {
 
 const Home: NextPage = () => {
   const [groupNumber, setGroupNumber] = useState(1)
-  const [errorMessage, setErrorMessage] = useState('')
+  const [additionalMember, setAdditionalMember] = useState('')
+  const [errorMessageOfGroupNumber, setErrorMessageOfGroupNumber] = useState('')
+  const [errorMessageOfAdditionalMember, setErrorMessageOfAdditionalMember] =
+    useState('')
 
   const [groups, setGroups] = useState<string[][]>([members])
 
-  const onChangeTextBox = (event: { target: { value: string } }) => {
+  const onChangeGroupNumber = (event: { target: { value: string } }) => {
     const parsedTargetValue = parseInt(event.target.value)
     setGroupNumber(parsedTargetValue)
 
     if (isNaN(parsedTargetValue)) {
-      setErrorMessage(errorMessages.numOfGroups['mustBeSpecified'])
+      setErrorMessageOfGroupNumber(
+        errorMessagesOfGroupNumber.numOfGroups['mustBeSpecified'],
+      )
       return
     } else if (parsedTargetValue === 0) {
-      setErrorMessage(errorMessages.numOfGroups['oneOrMore'])
+      setErrorMessageOfGroupNumber(
+        errorMessagesOfGroupNumber.numOfGroups['oneOrMore'],
+      )
       return
     } else if (parsedTargetValue > members.length) {
-      setErrorMessage(errorMessages.numOfGroups['memberNumberOrLess'])
+      setErrorMessageOfGroupNumber(
+        errorMessagesOfGroupNumber.numOfGroups['memberNumberOrLess'],
+      )
       return
     } else {
-      setErrorMessage('')
+      setErrorMessageOfGroupNumber('')
     }
 
     randomMembers.sort(() => 0.5 - Math.random())
     setGroups(divideGroups(parsedTargetValue, randomMembers))
+  }
+
+  const onClickAddButton = () => {
+    if (members.indexOf(additionalMember) >= 0) {
+      setErrorMessageOfAdditionalMember(
+        errorMessagesOfAdditionalMember.nameOfMembers[
+          'mustBeSpecifiedDifferent'
+        ],
+      )
+    } else if (additionalMember === '') {
+      setErrorMessageOfAdditionalMember(
+        errorMessagesOfAdditionalMember.nameOfMembers['mustBeSpecified'],
+      )
+    } else {
+      members.push(additionalMember)
+      randomMembers.push(additionalMember)
+      setGroups(divideGroups(groupNumber, randomMembers))
+      setAdditionalMember('')
+      setErrorMessageOfAdditionalMember('')
+    }
+  }
+
+  const onChangeAdditionalMember = (event: { target: { value: string } }) => {
+    setAdditionalMember(event.target.value)
+    setErrorMessageOfAdditionalMember('')
   }
 
   const memberNames: JSX.Element[] = []
@@ -128,13 +170,13 @@ const Home: NextPage = () => {
       <main className={styles.main}>
         <div>
           <p>グループ数</p>
-          <p className={styles.errorMessage}>{errorMessage}</p>
+          <p className={styles.errorMessage}>{errorMessageOfGroupNumber}</p>
           <input
             type='number'
             min='1'
             max={members.length}
             value={groupNumber}
-            onChange={onChangeTextBox}
+            onChange={onChangeGroupNumber}
           />
         </div>
         <p>メンバー一覧</p>
@@ -147,6 +189,22 @@ const Home: NextPage = () => {
             </thead>
             <tbody>{memberNames}</tbody>
           </table>
+        </div>
+        <div>
+          <p className={styles.errorMessage}>
+            {errorMessageOfAdditionalMember}
+          </p>
+          <input
+            type='text'
+            maxLength={12}
+            value={additionalMember}
+            onChange={onChangeAdditionalMember}
+          />
+          <input
+            type='button'
+            value='追加'
+            onClick={onClickAddButton}
+          />
         </div>
         <p>グループ分け結果</p>
         <div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,18 +92,17 @@ const Home: NextPage = () => {
     if (isNaN(parsedTargetValue)) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeSpecified)
       return
-    } else if (parsedTargetValue === 0) {
+    }
+    if (parsedTargetValue === 0) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.oneOrMore)
       return
-    } else if (parsedTargetValue > members.length) {
-      setErrorMessageOfGroupNumber(
-        errorMessages.numOfGroups.memberNumberOrLess,
-      )
-      return
-    } else {
-      setErrorMessageOfGroupNumber('')
     }
-
+    if (parsedTargetValue > members.length) {
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
+      return
+    }
+      
+    setErrorMessageOfGroupNumber('')
     randomMembers.sort(() => 0.5 - Math.random())
     setGroups(divideGroups(parsedTargetValue, randomMembers))
   }
@@ -113,17 +112,20 @@ const Home: NextPage = () => {
       setErrorMessageOfAdditionalMember(
         errorMessages.nameOfAdditionalMember.mustBeSpecifiedDifferent,
       )
-    } else if (additionalMember === '') {
+      return
+    }
+    if (additionalMember === '') {
       setErrorMessageOfAdditionalMember(
         errorMessages.nameOfAdditionalMember.mustBeSpecified,
       )
-    } else {
-      members.push(additionalMember)
-      randomMembers.push(additionalMember)
-      setGroups(divideGroups(groupNumber, randomMembers))
-      setAdditionalMember('')
-      setErrorMessageOfAdditionalMember('')
+      return
     }
+
+    members.push(additionalMember)
+    randomMembers.push(additionalMember)
+    setGroups(divideGroups(groupNumber, randomMembers))
+    setAdditionalMember('')
+    setErrorMessageOfAdditionalMember('')
   }
 
   const onChangeAdditionalMember = (event: { target: { value: string } }) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { useState } from 'react'
+import {KeyboardEvent, useState } from 'react'
 import styles from '../styles/Home.module.css'
 
 // グループメンバーのダミーデータ
@@ -133,11 +133,9 @@ const Home: NextPage = () => {
     setErrorMessageOfAdditionalMember('')
   }
 
-  const onClickEnter = () => {
-    document.onkeydown = (event) => {
-      if (event.key === 'Enter' && errorMessageOfGroupNumber == '') {
-        onClickAddButton()
-      }
+  const onClickEnter = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && errorMessageOfGroupNumber == '') {
+      onClickAddButton()
     }
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import {KeyboardEvent, useState } from 'react'
+import {ChangeEvent, KeyboardEvent, useState } from 'react'
 import styles from '../styles/Home.module.css'
 
 // グループメンバーのダミーデータ
@@ -85,7 +85,7 @@ const Home: NextPage = () => {
 
   const [groups, setGroups] = useState<string[][]>([members])
 
-  const onChangeGroupNumber = (event: { target: { value: string } }) => {
+  const onChangeGroupNumber = (event: ChangeEvent<HTMLInputElement>) => {
     const parsedTargetValue = parseInt(event.target.value)
     setGroupNumber(parsedTargetValue)
 
@@ -128,7 +128,7 @@ const Home: NextPage = () => {
     setErrorMessageOfAdditionalMember('')
   }
 
-  const onChangeAdditionalMember = (event: { target: { value: string } }) => {
+  const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
     setErrorMessageOfAdditionalMember('')
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -140,6 +140,14 @@ const Home: NextPage = () => {
     setErrorMessageOfAdditionalMember('')
   }
 
+  const onClickEnter = () => {
+    document.onkeydown = (event) => {
+      if (event.key === 'Enter' && errorMessageOfGroupNumber == '') {
+        onClickAddButton()
+      }
+    }
+  }
+
   const memberNames: JSX.Element[] = []
   for (let i = 0; i < members.length; i++) {
     memberNames.push(
@@ -199,6 +207,7 @@ const Home: NextPage = () => {
             maxLength={12}
             value={additionalMember}
             onChange={onChangeAdditionalMember}
+            onKeyDown={onClickEnter}
           />
           <input
             type='button'


### PR DESCRIPTION
- #2  
- 希望納期:11/24
- レビュアー: @rknakashima @yk-nakamura @RustyNail
- 仕様書: 無し

# 対応内容
### 機能追加
 - メンバー調整時にメンバーを追加できるようにした
     - バリデーションにより、同名のメンバーは追加できない旨をメッセージで表示する
     -  グループ数が0または未指定の場合にメンバー追加をするとエラーが出るため、その際はメンバー追加ボタンを無効とする

### バグ修正
- メンバー一覧のtr要素のkey属性に値を設定した
  - React開発ではDOMの変更がわかるようにkey指定が必要なため ( PR- #29 の実装ミス)


# 動作確認内容

1. メンバーの一覧表示の下にテキストボックスと追加ボタンが表示される
<img width="245" alt="スクリーンショット 2022-11-22 155858" src="https://user-images.githubusercontent.com/110072048/203246359-6fcce8cf-0aab-484c-a8a8-2f1a314b48b2.png">

1. メンバー追加の後、メンバー一覧とグループ分け結果に追加したメンバー名が含まれている
<img width="365" alt="スクリーンショット 2022-11-22 160214" src="https://user-images.githubusercontent.com/110072048/203246933-3f446ef2-702a-4966-8380-14ee112470dc.png">


1. テキストボックスが空文字のまま追加ボタンを押すと「名前を入力してください」とエラーメッセージが表示される
<img width="181" alt="スクリーンショット 2022-11-22 155955" src="https://user-images.githubusercontent.com/110072048/203246673-25ee1938-ecc2-4fa5-a088-b1345913dbcb.png">

1. テキストボックスに既存の名前を入れ追加ボタンを押すと「すでに存在する名前です、別の名前を入力してください」とエラーメッセージが表示される
<img width="227" alt="スクリーンショット 2022-11-22 160013" src="https://user-images.githubusercontent.com/110072048/203246699-a043ff51-20a0-4f82-81df-7e5e822413d3.png">

1.グループ数に関するエラーメッセージが表示されている時に追加ボタンが押せなくなっている
<img width="206" alt="スクリーンショット 2022-11-22 160117" src="https://user-images.githubusercontent.com/110072048/203246772-24f9af24-cba3-4a16-a8fb-25808264e94e.png">


# マージ前のチェックリスト

- [X] Issue に記載の DoD を満たしている
- [X] `yarn lint` の実行結果のスクリーンショットを添付している
<img width="593" alt="スクリーンショット 2022-11-22 155717" src="https://user-images.githubusercontent.com/110072048/203246007-ba895f8d-e5ee-4f2b-bcbb-86f15cf0ca81.png">


# 補足

- MVP実装時のアプリのUIは[Wiki](https://github.com/OJT-3G/random-grouping-app/wiki/%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AEUI)に記載してある。

- 下記についてはMVPの対応完了後に別issueで対応予定。
  * #27 
  * #17 
  * #16 
  * #25 
  * #30
