### PR TITLE
メンバーの調整のため、メンバー一覧からメンバーを削除出来るようにした

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { ChangeEvent, KeyboardEvent, useState } from 'react'
+import { ChangeEvent, KeyboardEvent, useEffect, useMemo, useState } from 'react'
 import styles from '../styles/Home.module.css'
 
 // グループメンバーのダミーデータ
@@ -67,7 +67,7 @@ const Home: NextPage = () => {
   const [additionalMember, setAdditionalMember] = useState('')
   const [lengthOfMembers, setLengthOfMembers] = useState(members.length)
 
-  const errorMessages = {
+  const errorMessages = useMemo(() => ({
     numOfGroups: {
       mustBeSpecified: 'グループ数を指定してください',
       oneOrMore: '1以上の整数を入力してください',
@@ -80,33 +80,40 @@ const Home: NextPage = () => {
       mustBeSpecifiedDifferent:
         'すでに存在する名前です、別の名前を入力してください',
     },
-  }
+  }), [lengthOfMembers])
   const [errorMessageOfGroupNumber, setErrorMessageOfGroupNumber] = useState('')
   const [errorMessageOfAdditionalMember, setErrorMessageOfAdditionalMember] =
     useState('')
 
   const [groups, setGroups] = useState<string[][]>([members])
 
-  const onChangeGroupNumber = (event: ChangeEvent<HTMLInputElement>) => {
-    const parsedTargetValue = parseInt(event.target.value)
-    setGroupNumber(parsedTargetValue)
-
-    if (isNaN(parsedTargetValue)) {
+  useEffect(() => {
+    if (lengthOfMembers === 0) {
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeAdded)
+      return
+    }
+    if (isNaN(groupNumber)) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeSpecified)
       return
     }
-    if (parsedTargetValue === 0) {
+    if (groupNumber === 0) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.oneOrMore)
       return
     }
-    if (parsedTargetValue > members.length) {
+    if (groupNumber > lengthOfMembers) {
+      console.log(lengthOfMembers)
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
       return
     }
 
     setErrorMessageOfGroupNumber('')
     randomMembers.sort(() => 0.5 - Math.random())
-    setGroups(divideGroups(parsedTargetValue, randomMembers))
+    setGroups(divideGroups(groupNumber, randomMembers))
+  }, [groupNumber, lengthOfMembers, errorMessages])
+
+  const onChangeGroupNumber = (event: ChangeEvent<HTMLInputElement>) => {
+    const parsedTargetValue = parseInt(event.target.value)
+    setGroupNumber(parsedTargetValue)
   }
 
   const onClickAddButton = () => {
@@ -139,11 +146,6 @@ const Home: NextPage = () => {
     randomMembers.splice(indexOfDeleteRandomMembers, 1)
     setGroups(divideGroups(groupNumber, randomMembers))
     setLengthOfMembers(members.length)
-
-    if (members.length === 0) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeAdded)
-      return
-    }
   }
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,6 +73,7 @@ const Home: NextPage = () => {
       oneOrMore: '1以上の整数を入力してください',
       memberNumberOrLess:
         'メンバー数(' + lengthOfMembers + ')以下の整数を入力してください',
+      mustBeAdded: 'メンバーがいません。追加してください',
     },
     nameOfAdditionalMember: {
       mustBeSpecified: '名前を入力してください',
@@ -127,6 +128,7 @@ const Home: NextPage = () => {
     setGroups(divideGroups(groupNumber, randomMembers))
     setLengthOfMembers(members.length)
     setAdditionalMember('')
+    setErrorMessageOfGroupNumber('')
     setErrorMessageOfAdditionalMember('')
   }
 
@@ -137,6 +139,11 @@ const Home: NextPage = () => {
     randomMembers.splice(indexOfDeleteRandomMembers, 1)
     setGroups(divideGroups(groupNumber, randomMembers))
     setLengthOfMembers(members.length)
+
+    if (members.length === 0) {
+      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeAdded)
+      return
+    }
   }
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
@@ -203,7 +210,8 @@ const Home: NextPage = () => {
             <thead className={styles.tableHead}>
               <tr>
                 <th>名前</th>
-                <th/>{/* 削除ボタン用の列 */}
+                <th />
+                {/* 削除ボタン用の列 */}
               </tr>
             </thead>
             <tbody>{memberNames}</tbody>
@@ -223,7 +231,7 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='追加'
-            disabled={errorMessageOfGroupNumber !== ''}
+            disabled={errorMessageOfGroupNumber !== '' && members.length !== 0}
             onClick={onClickAddButton}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -101,7 +101,6 @@ const Home: NextPage = () => {
       return
     }
     if (groupNumber > lengthOfMembers) {
-      console.log(lengthOfMembers)
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
       return
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -131,11 +131,10 @@ const Home: NextPage = () => {
   }
 
   const onClickDeleteButton = (deleteMember: string) => {
-    const startOfDeleteMember = members.indexOf(deleteMember)
-    const startOfDeleteRandomMembers = randomMembers.indexOf(deleteMember)
-    const deleteCount = 1
-    members.splice(startOfDeleteMember, deleteCount)
-    randomMembers.splice(startOfDeleteRandomMembers, deleteCount)
+    const indexOfDeleteMember = members.indexOf(deleteMember)
+    const indexOfDeleteRandomMembers = randomMembers.indexOf(deleteMember)
+    members.splice(indexOfDeleteMember, 1)
+    randomMembers.splice(indexOfDeleteRandomMembers, 1)
     setGroups(divideGroups(groupNumber, randomMembers))
     setLengthOfMembers(members.length)
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import {ChangeEvent, KeyboardEvent, useState } from 'react'
+import { ChangeEvent, KeyboardEvent, useState } from 'react'
 import styles from '../styles/Home.module.css'
 
 // グループメンバーのダミーデータ
@@ -20,20 +20,6 @@ const members = [
 ]
 
 const randomMembers = [...members]
-
-const errorMessages = {
-  numOfGroups: {
-    mustBeSpecified: 'グループ数を指定してください',
-    oneOrMore: '1以上の整数を入力してください',
-    memberNumberOrLess:
-      'メンバー数(' + members.length + ')以下の整数を入力してください',
-  },
-  nameOfAdditionalMember: {
-    mustBeSpecified: '名前を入力してください',
-    mustBeSpecifiedDifferent:
-      'すでに存在する名前です、別の名前を入力してください',
-  },
-}
 
 const divideGroups = (groupNumber: number, members: string[]) => {
   const minMemberNum = Math.floor(members.length / groupNumber)
@@ -79,6 +65,21 @@ const transpose = (twoDimensionalArray: string[][]) => {
 const Home: NextPage = () => {
   const [groupNumber, setGroupNumber] = useState(1)
   const [additionalMember, setAdditionalMember] = useState('')
+  const [lengthOfMembers, setLengthOfMembers] = useState(members.length)
+
+  const errorMessages = {
+    numOfGroups: {
+      mustBeSpecified: 'グループ数を指定してください',
+      oneOrMore: '1以上の整数を入力してください',
+      memberNumberOrLess:
+        'メンバー数(' + lengthOfMembers + ')以下の整数を入力してください',
+    },
+    nameOfAdditionalMember: {
+      mustBeSpecified: '名前を入力してください',
+      mustBeSpecifiedDifferent:
+        'すでに存在する名前です、別の名前を入力してください',
+    },
+  }
   const [errorMessageOfGroupNumber, setErrorMessageOfGroupNumber] = useState('')
   const [errorMessageOfAdditionalMember, setErrorMessageOfAdditionalMember] =
     useState('')
@@ -101,7 +102,7 @@ const Home: NextPage = () => {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
       return
     }
-      
+
     setErrorMessageOfGroupNumber('')
     randomMembers.sort(() => 0.5 - Math.random())
     setGroups(divideGroups(parsedTargetValue, randomMembers))
@@ -124,6 +125,7 @@ const Home: NextPage = () => {
     members.push(additionalMember)
     randomMembers.push(additionalMember)
     setGroups(divideGroups(groupNumber, randomMembers))
+    setLengthOfMembers(members.length)
     setAdditionalMember('')
     setErrorMessageOfAdditionalMember('')
   }
@@ -135,6 +137,7 @@ const Home: NextPage = () => {
     members.splice(startOfDeleteMember, deleteCount)
     randomMembers.splice(startOfDeleteRandomMembers, deleteCount)
     setGroups(divideGroups(groupNumber, randomMembers))
+    setLengthOfMembers(members.length)
   }
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -67,20 +67,23 @@ const Home: NextPage = () => {
   const [additionalMember, setAdditionalMember] = useState('')
   const [lengthOfMembers, setLengthOfMembers] = useState(members.length)
 
-  const errorMessages = useMemo(() => ({
-    numOfGroups: {
-      mustBeSpecified: 'グループ数を指定してください',
-      oneOrMore: '1以上の整数を入力してください',
-      memberNumberOrLess:
-        'メンバー数(' + lengthOfMembers + ')以下の整数を入力してください',
-    },
-    nameOfAdditionalMember: {
-      mustBeSpecified: '名前を入力してください',
-      mustBeSpecifiedDifferent:
-        'すでに存在する名前です、別の名前を入力してください',
-      mustBeAdded: 'メンバーがいません、追加してください',
-    },
-  }), [lengthOfMembers])
+  const errorMessages = useMemo(
+    () => ({
+      numOfGroups: {
+        mustBeSpecified: 'グループ数を指定してください',
+        oneOrMore: '1以上の整数を入力してください',
+        memberNumberOrLess:
+          'メンバー数(' + lengthOfMembers + ')以下の整数を入力してください',
+      },
+      nameOfAdditionalMember: {
+        mustBeSpecified: '名前を入力してください',
+        mustBeSpecifiedDifferent:
+          'すでに存在する名前です、別の名前を入力してください',
+        mustBeAdded: 'メンバーがいません、追加してください',
+      },
+    }),
+    [lengthOfMembers],
+  )
   const [errorMessageOfGroupNumber, setErrorMessageOfGroupNumber] = useState('')
   const [errorMessageOfAdditionalMember, setErrorMessageOfAdditionalMember] =
     useState('')
@@ -89,7 +92,9 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     if (lengthOfMembers === 0) {
-      setErrorMessageOfAdditionalMember(errorMessages.nameOfAdditionalMember.mustBeAdded)
+      setErrorMessageOfAdditionalMember(
+        errorMessages.nameOfAdditionalMember.mustBeAdded,
+      )
       return
     }
     if (isNaN(groupNumber)) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -207,7 +207,7 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
-            disabled={errorMessageOfAdditionalMember === errorMessages.nameOfAdditionalMember.mustBeAdded}
+            disabled={errorMessageOfAdditionalMember !== ''}
             onChange={onChangeGroupNumber}
           />
         </div>
@@ -238,7 +238,7 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='追加'
-            disabled={errorMessageOfGroupNumber !== '' && members.length !== 0}
+            disabled={errorMessageOfGroupNumber !== ''}
             onClick={onClickAddButton}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -202,6 +202,7 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
+            disabled={errorMessageOfGroupNumber === errorMessages.numOfGroups.mustBeAdded}
             onChange={onChangeGroupNumber}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,7 +129,7 @@ const Home: NextPage = () => {
       return
     }
     if (additionalMember === '') {
-      if (whetherMemberIsNecessary()) {
+      if (isExistMembers()) {
         setErrorMessageOfAdditionalMember(
           errorMessages.nameOfAdditionalMember.mustBeSpecified,
         )
@@ -146,9 +146,8 @@ const Home: NextPage = () => {
     setErrorMessageOfAdditionalMember('')
   }
 
-  const whetherMemberIsNecessary = () => {
-    const judge = errorMessageOfAdditionalMember !== errorMessages.nameOfAdditionalMember.mustBeAdded
-    return judge
+  const isExistMembers = () => {
+    return lengthOfMembers !== 0
   }
 
   const onClickDeleteButton = (deleteMember: string) => {
@@ -163,7 +162,7 @@ const Home: NextPage = () => {
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
-    if (whetherMemberIsNecessary()) {
+    if (isExistMembers()) {
       setErrorMessageOfAdditionalMember('')
     }
   }
@@ -218,7 +217,7 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
-            disabled={!whetherMemberIsNecessary()}
+            disabled={!isExistMembers()}
             onChange={onChangeGroupNumber}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,12 +73,12 @@ const Home: NextPage = () => {
       oneOrMore: '1以上の整数を入力してください',
       memberNumberOrLess:
         'メンバー数(' + lengthOfMembers + ')以下の整数を入力してください',
-      mustBeAdded: 'メンバーがいません、追加してください',
     },
     nameOfAdditionalMember: {
       mustBeSpecified: '名前を入力してください',
       mustBeSpecifiedDifferent:
         'すでに存在する名前です、別の名前を入力してください',
+      mustBeAdded: 'メンバーがいません、追加してください',
     },
   }), [lengthOfMembers])
   const [errorMessageOfGroupNumber, setErrorMessageOfGroupNumber] = useState('')
@@ -89,7 +89,7 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     if (lengthOfMembers === 0) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeAdded)
+      setErrorMessageOfAdditionalMember(errorMessages.nameOfAdditionalMember.mustBeAdded)
       return
     }
     if (isNaN(groupNumber)) {
@@ -202,7 +202,7 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
-            disabled={errorMessageOfGroupNumber === errorMessages.numOfGroups.mustBeAdded}
+            disabled={errorMessageOfAdditionalMember === errorMessages.nameOfAdditionalMember.mustBeAdded}
             onChange={onChangeGroupNumber}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -160,6 +160,7 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='削除'
+            disabled={errorMessageOfGroupNumber !== ''}
             onClick={() => onClickDeleteButton(members[i])}
           />
         </td>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -154,7 +154,6 @@ const Home: NextPage = () => {
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
-
   }
 
   const onClickEnter = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -172,7 +171,10 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='削除'
-            disabled={errorMessageOfGroupNumber !== '' || errorMessageOfAdditionalMember !== ''}
+            disabled={
+              errorMessageOfGroupNumber !== '' ||
+              errorMessageOfAdditionalMember !== ''
+            }
             onClick={() => onClickDeleteButton(members[i])}
           />
         </td>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,7 +73,7 @@ const Home: NextPage = () => {
       oneOrMore: '1以上の整数を入力してください',
       memberNumberOrLess:
         'メンバー数(' + lengthOfMembers + ')以下の整数を入力してください',
-      mustBeAdded: 'メンバーがいません。追加してください',
+      mustBeAdded: 'メンバーがいません、追加してください',
     },
     nameOfAdditionalMember: {
       mustBeSpecified: '名前を入力してください',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -154,12 +154,7 @@ const Home: NextPage = () => {
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
-    if (
-      errorMessageOfAdditionalMember !==
-      errorMessages.nameOfAdditionalMember.mustBeAdded
-    ) {
-      setErrorMessageOfAdditionalMember('')
-    }
+
   }
 
   const onClickEnter = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -177,7 +172,7 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='削除'
-            disabled={errorMessageOfGroupNumber !== ''}
+            disabled={errorMessageOfGroupNumber !== '' || errorMessageOfAdditionalMember !== ''}
             onClick={() => onClickDeleteButton(members[i])}
           />
         </td>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -204,7 +204,7 @@ const Home: NextPage = () => {
             <thead className={styles.tableHead}>
               <tr>
                 <th>名前</th>
-                <th></th>
+                <th/>{/* 削除ボタン用の列 */}
               </tr>
             </thead>
             <tbody>{memberNames}</tbody>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -128,9 +128,14 @@ const Home: NextPage = () => {
       return
     }
     if (additionalMember === '') {
-      setErrorMessageOfAdditionalMember(
-        errorMessages.nameOfAdditionalMember.mustBeSpecified,
-      )
+      if (
+        errorMessageOfAdditionalMember !==
+        errorMessages.nameOfAdditionalMember.mustBeAdded
+      ) {
+        setErrorMessageOfAdditionalMember(
+          errorMessages.nameOfAdditionalMember.mustBeSpecified,
+        )
+      }
       return
     }
 
@@ -154,6 +159,12 @@ const Home: NextPage = () => {
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
+    if (
+      errorMessageOfAdditionalMember !==
+      errorMessages.nameOfAdditionalMember.mustBeAdded
+    ) {
+      setErrorMessageOfAdditionalMember('')
+    }
   }
 
   const onClickEnter = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -172,8 +183,8 @@ const Home: NextPage = () => {
             type='button'
             value='削除'
             disabled={
-              errorMessageOfGroupNumber !== '' ||
-              errorMessageOfAdditionalMember !== ''
+              errorMessageOfAdditionalMember ===
+              errorMessages.nameOfAdditionalMember.mustBeAdded
             }
             onClick={() => onClickDeleteButton(members[i])}
           />
@@ -209,7 +220,6 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
-            disabled={errorMessageOfAdditionalMember !== ''}
             onChange={onChangeGroupNumber}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -111,7 +111,7 @@ const Home: NextPage = () => {
 
     setErrorMessageOfGroupNumber(errorMessage)
 
-    if(errorMessage !== ''){
+    if (errorMessage !== '') {
       return
     }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -128,6 +128,15 @@ const Home: NextPage = () => {
     setErrorMessageOfAdditionalMember('')
   }
 
+  const onClickDeleteButton = (deleteMember: string) => {
+    const startOfDeleteMember = members.indexOf(deleteMember)
+    const startOfDeleteRandomMembers = randomMembers.indexOf(deleteMember)
+    const deleteCount = 1
+    members.splice(startOfDeleteMember, deleteCount)
+    randomMembers.splice(startOfDeleteRandomMembers, deleteCount)
+    setGroups(divideGroups(groupNumber, randomMembers))
+  }
+
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
     setErrorMessageOfAdditionalMember('')
@@ -144,6 +153,13 @@ const Home: NextPage = () => {
     memberNames.push(
       <tr key={members[i]}>
         <td>{members[i]}</td>
+        <td>
+          <input
+            type='button'
+            value='削除'
+            onClick={() => onClickDeleteButton(members[i])}
+          />
+        </td>
       </tr>,
     )
   }
@@ -184,6 +200,7 @@ const Home: NextPage = () => {
             <thead className={styles.tableHead}>
               <tr>
                 <th>名前</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>{memberNames}</tbody>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -91,6 +91,7 @@ const Home: NextPage = () => {
   const [groups, setGroups] = useState<string[][]>([members])
 
   useEffect(() => {
+    setErrorMessageOfAdditionalMember('')
     if (lengthOfMembers === 0) {
       setErrorMessageOfAdditionalMember(
         errorMessages.nameOfAdditionalMember.mustBeAdded,
@@ -99,7 +100,6 @@ const Home: NextPage = () => {
     }
     if (isNaN(groupNumber)) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeSpecified)
-      setErrorMessageOfAdditionalMember('')
       return
     }
     if (groupNumber === 0) {
@@ -108,12 +108,10 @@ const Home: NextPage = () => {
     }
     if (groupNumber > lengthOfMembers) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
-      setErrorMessageOfAdditionalMember('')
       return
     }
 
     setErrorMessageOfGroupNumber('')
-    setErrorMessageOfAdditionalMember('')
     randomMembers.sort(() => 0.5 - Math.random())
     setGroups(divideGroups(groupNumber, randomMembers))
   }, [groupNumber, lengthOfMembers, errorMessages])

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -98,20 +98,23 @@ const Home: NextPage = () => {
       )
       return
     }
+    let errorMessage = ''
     if (isNaN(groupNumber)) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeSpecified)
-      return
+      errorMessage = errorMessages.numOfGroups.mustBeSpecified
     }
     if (groupNumber === 0) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.oneOrMore)
-      return
+      errorMessage = errorMessages.numOfGroups.oneOrMore
     }
     if (groupNumber > lengthOfMembers) {
-      setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
+      errorMessage = errorMessages.numOfGroups.memberNumberOrLess
+    }
+
+    setErrorMessageOfGroupNumber(errorMessage)
+
+    if(errorMessage !== ''){
       return
     }
 
-    setErrorMessageOfGroupNumber('')
     randomMembers.sort(() => 0.5 - Math.random())
     setGroups(divideGroups(groupNumber, randomMembers))
   }, [groupNumber, lengthOfMembers, errorMessages])

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -99,6 +99,7 @@ const Home: NextPage = () => {
     }
     if (isNaN(groupNumber)) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.mustBeSpecified)
+      setErrorMessageOfAdditionalMember('')
       return
     }
     if (groupNumber === 0) {
@@ -107,10 +108,12 @@ const Home: NextPage = () => {
     }
     if (groupNumber > lengthOfMembers) {
       setErrorMessageOfGroupNumber(errorMessages.numOfGroups.memberNumberOrLess)
+      setErrorMessageOfAdditionalMember('')
       return
     }
 
     setErrorMessageOfGroupNumber('')
+    setErrorMessageOfAdditionalMember('')
     randomMembers.sort(() => 0.5 - Math.random())
     setGroups(divideGroups(groupNumber, randomMembers))
   }, [groupNumber, lengthOfMembers, errorMessages])
@@ -155,6 +158,7 @@ const Home: NextPage = () => {
     randomMembers.splice(indexOfDeleteRandomMembers, 1)
     setGroups(divideGroups(groupNumber, randomMembers))
     setLengthOfMembers(members.length)
+    setErrorMessageOfAdditionalMember('')
   }
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -149,7 +149,12 @@ const Home: NextPage = () => {
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
-    setErrorMessageOfAdditionalMember('')
+    if (
+      errorMessageOfAdditionalMember !==
+      errorMessages.nameOfAdditionalMember.mustBeAdded
+    ) {
+      setErrorMessageOfAdditionalMember('')
+    }
   }
 
   const onClickEnter = (event: KeyboardEvent<HTMLInputElement>) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,10 +129,7 @@ const Home: NextPage = () => {
       return
     }
     if (additionalMember === '') {
-      if (
-        errorMessageOfAdditionalMember !==
-        errorMessages.nameOfAdditionalMember.mustBeAdded
-      ) {
+      if (whetherMemberIsNecessary()) {
         setErrorMessageOfAdditionalMember(
           errorMessages.nameOfAdditionalMember.mustBeSpecified,
         )
@@ -149,6 +146,11 @@ const Home: NextPage = () => {
     setErrorMessageOfAdditionalMember('')
   }
 
+  const whetherMemberIsNecessary = () => {
+    const judge = errorMessageOfAdditionalMember !== errorMessages.nameOfAdditionalMember.mustBeAdded
+    return judge
+  }
+
   const onClickDeleteButton = (deleteMember: string) => {
     const indexOfDeleteMember = members.indexOf(deleteMember)
     const indexOfDeleteRandomMembers = randomMembers.indexOf(deleteMember)
@@ -161,10 +163,7 @@ const Home: NextPage = () => {
 
   const onChangeAdditionalMember = (event: ChangeEvent<HTMLInputElement>) => {
     setAdditionalMember(event.target.value)
-    if (
-      errorMessageOfAdditionalMember !==
-      errorMessages.nameOfAdditionalMember.mustBeAdded
-    ) {
+    if (whetherMemberIsNecessary()) {
       setErrorMessageOfAdditionalMember('')
     }
   }
@@ -219,7 +218,7 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
-            disabled={errorMessageOfAdditionalMember === errorMessages.nameOfAdditionalMember.mustBeAdded}
+            disabled={!whetherMemberIsNecessary()}
             onChange={onChangeGroupNumber}
           />
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -186,10 +186,7 @@ const Home: NextPage = () => {
           <input
             type='button'
             value='削除'
-            disabled={
-              errorMessageOfAdditionalMember ===
-              errorMessages.nameOfAdditionalMember.mustBeAdded
-            }
+            disabled={errorMessageOfGroupNumber !== ''}
             onClick={() => onClickDeleteButton(members[i])}
           />
         </td>
@@ -224,6 +221,7 @@ const Home: NextPage = () => {
             min='1'
             max={members.length}
             value={groupNumber}
+            disabled={errorMessageOfAdditionalMember === errorMessages.nameOfAdditionalMember.mustBeAdded}
             onChange={onChangeGroupNumber}
           />
         </div>


### PR DESCRIPTION
- Resolve #1
- 希望納期:11/28
- レビュアー: @rknakashima @yk-nakamura @RustyNail
- 仕様書: 無し

# 対応内容
### 機能追加
 - メンバー調整時にメンバーを削除できるようにした

### バグ修正
- 無し

# 動作確認内容
1.メンバー一覧の削除ボタン押下後、メンバー一覧とグループ分け結果から削除したメンバー名が消えている(以下はメンバー一覧から「にしかわ」を消した際の画像である)
<img width="301" alt="スクリーンショット 2022-11-25 131352" src="https://user-images.githubusercontent.com/110072048/203900001-43f78684-0b54-48f4-9093-fe047dfd70d1.png">

<img width="240" alt="スクリーンショット 2022-11-25 131409" src="https://user-images.githubusercontent.com/110072048/203900006-ea6948a4-ff37-4960-8df9-a14d782b1a9c.png">

# マージ前のチェックリスト

- [X] Issue に記載の DoD を満たしている
- [X] `yarn lint` の実行結果のスクリーンショットを添付している
<img width="516" alt="スクリーンショット 2022-11-25 120254" src="https://user-images.githubusercontent.com/110072048/203899504-9f00bebc-02ca-4ce9-be79-a50745979157.png">

# 補足

- MVP実装時のアプリのUIは[Wiki](https://github.com/OJT-3G/random-grouping-app/wiki/%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AEUI)に記載してある。

- 下記についてはMVPの対応完了後に別issueで対応予定。
  * #27 
  * #17 
  * #16 
  * #25 
  * #30